### PR TITLE
Use a constant update rather than relying on VIGNETTES_UPDATED

### DIFF
--- a/ScrapHeapEvents.lua
+++ b/ScrapHeapEvents.lua
@@ -123,9 +123,9 @@ function ns.DrawLine(pin, type, xy1, xy2, mapType)
 	return (x1 + x2) / 2, (y1 + y2) / 2
 end
 
-function ns.VignettesUpdated()
+function ns.DoUpdate()
 	-- Let's not check this too often
-	if (GetServerTime() - lastUpdatedTime < 1) then
+	if (GetServerTime() - lastUpdatedTime < 2) then
 		return
 	end
 	-- print(GetServerTime())
@@ -180,9 +180,7 @@ local UpdateFrame = CreateFrame("frame")
 
 -- Need this function to remove the line once the event is complete
 function UpdateFrame:OnEvent(event, arg1, ...)
-	if event == "VIGNETTES_UPDATED" then
-		ns.VignettesUpdated()
-	elseif event == "ZONE_CHANGED_NEW_AREA" then
+	if event == "ZONE_CHANGED_NEW_AREA" then
 		if not addonConfig["Enabled"] then
 			ns.Disable()
 			return
@@ -231,10 +229,10 @@ end
 function ns.ShouldBeActive()
 	if C_Map.GetBestMapForUnit("player") == TRACKED_MAP_ID then
 		-- print("everything activated")
-		UpdateFrame:RegisterEvent("VIGNETTES_UPDATED")
+		UpdateFrame:SetScript("OnUpdate", ns.DoUpdate)
 	else
 		-- print("Wrong zone, inactive")
-		UpdateFrame:UnregisterEvent("VIGNETTES_UPDATED")
+		ns.Disable()
 	end
 end
 
@@ -246,7 +244,7 @@ end
 -- If the user wants the addon disabled
 function ns.Disable()
 	ns.HideLines()
-	UpdateFrame:UnregisterEvent("VIGNETTES_UPDATED")
+	UpdateFrame:SetScript("OnUpdate", nil)
 end
 
 -- Toggle the enabled-state of the addon

--- a/ScrapHeapEvents.toc
+++ b/ScrapHeapEvents.toc
@@ -2,7 +2,7 @@
 ## Title: Scrap Heap Events
 ## Notes: Shows a line from your location to the S.C.R.A.P. Heap events in Undermine
 ## Author: Protuhj
-## Version: 110100_05
+## Version: 110100_06
 ## DefaultState: Enabled
 ## SavedVariables: addonConfig
 ScrapHeapEventsMixin.xml


### PR DESCRIPTION
VIGNETTES_UPDATED could come hot and heavy, or > 10 seconds when the zone is quiet and vignettes aren't popping up left and right

Also fixed an issue where the line could get stuck on your map if you left the zone while a line was active